### PR TITLE
Support proto_tree_add_int_format_value()

### DIFF
--- a/plugins/epan/mruby/ws_dissector.rb
+++ b/plugins/epan/mruby/ws_dissector.rb
@@ -1,6 +1,5 @@
 class WSDissector
-  ENC_BIG_ENDIAN  = nil # Implement in ws_protocol.c
-  FORMAT_ADD_ITEM = :format_add_item
+  ENC_BIG_ENDIAN  = nil # C側で実装
 
   def initialize(name:, depth:)
     @name     = name

--- a/plugins/epan/mruby/ws_protocol.c
+++ b/plugins/epan/mruby/ws_protocol.c
@@ -73,6 +73,20 @@ static void ws_protocol_tree_add(mrb_state *mrb, mrb_value mrb_sym,
   }
 }
 
+static bool ws_protocol_is_default_display(mrb_state *mrb, int format)
+{
+  int default_display = (int)mrb_obj_to_sym(mrb, mrb_str_new_lit(mrb, "format_add_item"));
+
+  return default_display == format;
+}
+
+static bool ws_protocol_is_formatted_int_display(mrb_state *mrb, int format)
+{
+  int formatted_int_display = (int)mrb_obj_to_sym(mrb, mrb_str_new_lit(mrb, "format_add_int_item"));
+
+  return formatted_int_display == format;
+}
+
 static void ws_protocol_add_items(mrb_state *mrb, mrb_value mrb_items, proto_item *ti, tvbuff_t *tvb)
 {
   for (int i = 0; i < (int)RARRAY_LEN(mrb_items); i++) {
@@ -87,9 +101,14 @@ static void ws_protocol_add_items(mrb_state *mrb, mrb_value mrb_items, proto_ite
 
     if (mrb_nil_p(mrb_display)) mrb_display = MRB_SYM(mrb, "format_add_item");
 
-    ws_protocol_tree_add(mrb, mrb_display,
-                         ti, ws_header.handle, tvb,
-                         (int)mrb_fixnum(mrb_offset), (int)mrb_fixnum(mrb_size), (int)mrb_fixnum(mrb_endian));
+    int ws_display_spec = (int)mrb_obj_to_sym(mrb, mrb_display);
+
+    if (ws_protocol_is_default_display(mrb, ws_display_spec)) {
+      proto_tree_add_item(ti, ws_header.handle, tvb,
+                          (int)mrb_fixnum(mrb_offset),
+                          (int)mrb_fixnum(mrb_size),
+                          (int)mrb_fixnum(mrb_endian));
+    }
   }
 }
 

--- a/plugins/epan/mruby/ws_protocol.c
+++ b/plugins/epan/mruby/ws_protocol.c
@@ -85,6 +85,7 @@ static void ws_protocol_add_items(mrb_state *mrb, mrb_value mrb_items, proto_ite
     mrb_value mrb_endian  = mrb_funcall(mrb, mrb_item,  "dig",   1, MRB_SYM(mrb, "endian"));
 
     ws_header_t ws_header = ws_protocol_detect_header(mrb_obj_to_sym(mrb, mrb_symbol));
+    mrb_value mrb_fmt, mrb_val;
 
     if (mrb_nil_p(mrb_display)) mrb_display = MRB_SYM(mrb, "format_add_item");
 
@@ -95,6 +96,15 @@ static void ws_protocol_add_items(mrb_state *mrb, mrb_value mrb_items, proto_ite
                           (int)mrb_fixnum(mrb_offset),
                           (int)mrb_fixnum(mrb_size),
                           (int)mrb_fixnum(mrb_endian));
+    } else if (ws_protocol_is_formatted_int_display(mrb, ws_display_spec)) {
+      mrb_fmt = mrb_funcall(mrb, mrb_item, "fetch", 1, MRB_SYM(mrb, "format"));
+      mrb_val = mrb_funcall(mrb, mrb_item, "fetch", 1, MRB_SYM(mrb, "value"));
+      proto_tree_add_int_format_value(ti, ws_header.handle, tvb,
+                                      (int)mrb_fixnum(mrb_offset),
+                                      (int)mrb_fixnum(mrb_size),
+                                      (gint32)mrb_fixnum(mrb_val),
+                                      mrb_string_cstr(mrb, mrb_fmt),
+                                      (gint32)mrb_fixnum(mrb_val));
     }
   }
 }

--- a/plugins/epan/mruby/ws_protocol.c
+++ b/plugins/epan/mruby/ws_protocol.c
@@ -76,21 +76,18 @@ static void ws_protocol_tree_add(mrb_state *mrb, mrb_value mrb_sym,
 static void ws_protocol_add_items(mrb_state *mrb, mrb_value mrb_items, proto_item *ti, tvbuff_t *tvb)
 {
   for (int i = 0; i < (int)RARRAY_LEN(mrb_items); i++) {
-    mrb_value   mrb_item   = mrb_funcall(mrb, mrb_items, "fetch", 1, mrb_fixnum_value(i));
-    mrb_value   mrb_size   = mrb_funcall(mrb, mrb_item,  "fetch", 1, MRB_SYM(mrb, "size"));
-    mrb_value   mrb_offset = mrb_funcall(mrb, mrb_item,  "fetch", 1, MRB_SYM(mrb, "offset"));
-    mrb_value   mrb_endian = mrb_funcall(mrb, mrb_item,  "fetch", 1, MRB_SYM(mrb, "endian"));
-    mrb_value   mrb_symbol = mrb_funcall(mrb, mrb_item,  "fetch", 1, MRB_SYM(mrb, "header"));
-    ws_header_t ws_header  = ws_protocol_detect_header(mrb_obj_to_sym(mrb, mrb_symbol));
+    mrb_value mrb_item    = mrb_funcall(mrb, mrb_items, "fetch", 1, mrb_fixnum_value(i));
+    mrb_value mrb_size    = mrb_funcall(mrb, mrb_item,  "fetch", 1, MRB_SYM(mrb, "size"));
+    mrb_value mrb_offset  = mrb_funcall(mrb, mrb_item,  "fetch", 1, MRB_SYM(mrb, "offset"));
+    mrb_value mrb_symbol  = mrb_funcall(mrb, mrb_item,  "fetch", 1, MRB_SYM(mrb, "header"));
+    mrb_value mrb_display = mrb_funcall(mrb, mrb_item,  "dig",   1, MRB_SYM(mrb, "display"));
+    mrb_value mrb_endian  = mrb_funcall(mrb, mrb_item,  "dig",   1, MRB_SYM(mrb, "endian"));
 
-    mrb_value mrb_fmt = mrb_funcall(mrb, mrb_item, "fetch", 2, MRB_SYM(mrb, "format"), mrb_hash_new(mrb));
-    mrb_value mrb_fmt_type = mrb_funcall(mrb, mrb_fmt, "fetch", 2, MRB_SYM(mrb, "type"), mrb_nil_value());
+    ws_header_t ws_header = ws_protocol_detect_header(mrb_obj_to_sym(mrb, mrb_symbol));
 
-    if (mrb_nil_p(mrb_fmt_type)) {
-      mrb_fmt_type = MRB_SYM(mrb, "format_add_item");
-    }
+    if (mrb_nil_p(mrb_display)) mrb_display = MRB_SYM(mrb, "format_add_item");
 
-    ws_protocol_tree_add(mrb, mrb_fmt_type,
+    ws_protocol_tree_add(mrb, mrb_display,
                          ti, ws_header.handle, tvb,
                          (int)mrb_fixnum(mrb_offset), (int)mrb_fixnum(mrb_size), (int)mrb_fixnum(mrb_endian));
   }

--- a/plugins/epan/mruby/ws_protocol.c
+++ b/plugins/epan/mruby/ws_protocol.c
@@ -62,14 +62,14 @@ static ws_header_t ws_protocol_detect_header(int symbol)
 
 static bool ws_protocol_is_default_display(mrb_state *mrb, int format)
 {
-  int default_display = (int)mrb_obj_to_sym(mrb, mrb_str_new_lit(mrb, "format_add_item"));
+  int default_display = (int)mrb_obj_to_sym(mrb, mrb_str_new_lit(mrb, "default"));
 
   return default_display == format;
 }
 
 static bool ws_protocol_is_formatted_int_display(mrb_state *mrb, int format)
 {
-  int formatted_int_display = (int)mrb_obj_to_sym(mrb, mrb_str_new_lit(mrb, "format_add_int_item"));
+  int formatted_int_display = (int)mrb_obj_to_sym(mrb, mrb_str_new_lit(mrb, "formatted_int"));
 
   return formatted_int_display == format;
 }
@@ -87,7 +87,7 @@ static void ws_protocol_add_items(mrb_state *mrb, mrb_value mrb_items, proto_ite
     ws_header_t ws_header = ws_protocol_detect_header(mrb_obj_to_sym(mrb, mrb_symbol));
     mrb_value mrb_fmt, mrb_val;
 
-    if (mrb_nil_p(mrb_display)) mrb_display = MRB_SYM(mrb, "format_add_item");
+    if (mrb_nil_p(mrb_display)) mrb_display = MRB_SYM(mrb, "default");
 
     int ws_display_spec = (int)mrb_obj_to_sym(mrb, mrb_display);
 

--- a/plugins/epan/mruby/ws_protocol.c
+++ b/plugins/epan/mruby/ws_protocol.c
@@ -60,19 +60,6 @@ static ws_header_t ws_protocol_detect_header(int symbol)
   exit(1);
 }
 
-static void ws_protocol_tree_add(mrb_state *mrb, mrb_value mrb_sym,
-                                 proto_item *ti, int handle, tvbuff_t *tvb,
-                                 int offset, int size, int endian)
-{
-  int format_spec     = (int)mrb_obj_to_sym(mrb, mrb_sym);
-  int add_item_format = (int)mrb_obj_to_sym(mrb, mrb_str_new_lit(mrb, "format_add_item"));
-
-  if (format_spec == add_item_format) {
-    proto_tree_add_item(ti, handle, tvb, offset, size, endian);
-    return;
-  }
-}
-
 static bool ws_protocol_is_default_display(mrb_state *mrb, int format)
 {
   int default_display = (int)mrb_obj_to_sym(mrb, mrb_str_new_lit(mrb, "format_add_item"));


### PR DESCRIPTION
* Make config interface simple
* Support `proto_tree_add_int_format_value()`
* Change value in config for `selecting proto_tree_add_...` functions
* Remove unnecessary function for `selecting proto_tree_add_...` functions