### PR TITLE
Create new mrb_state once

### DIFF
--- a/plugins/epan/foo/packet-foo.c
+++ b/plugins/epan/foo/packet-foo.c
@@ -1,8 +1,6 @@
 #include "config.h"
 #include <epan/packet.h>
 
-#include <mruby.h>
-#include <mruby/compile.h>
 #include "../plugins/epan/mruby/ws_protocol.c"
 
 void proto_register_foo(void)
@@ -11,9 +9,5 @@ void proto_register_foo(void)
 
 void proto_reg_handoff_foo(void)
 {
-  mrb_state *mrb = mrb_open();
-
-  mrb_ws_protocol_start(mrb, "../plugins/epan/foo/config.foo.rb");
-
-  mrb_close(mrb);
+  mrb_ws_protocol_start("../plugins/epan/foo/config.foo.rb");
 }


### PR DESCRIPTION
### Before the change
`mrb_state` was first created in the handoff function, and it was released when the function finishes.
Therefore, `mrb_state` could not be reused and had to be re-created each time traffic occurred.

### After the change
Create the `mrb_state` in the `mrb_ws_protocol_start` function when Wireshark starts and never release it.
This allows the first `mrb_state` created to be used around.
At the same time, the handoff function is simply used to call the `mrb_ws_protocol_start` function and does not depend on mruby.