### PR TITLE
Execute mrb_ws_protocol_start_once only when Wireshark starts

### DIFF
--- a/plugins/epan/mruby/ws_protocol.c
+++ b/plugins/epan/mruby/ws_protocol.c
@@ -152,7 +152,9 @@ static int ws_protocol_dissector(tvbuff_t *tvb, packet_info *pinfo, proto_tree *
   if (operation_mode != DISSECTION) operation_mode = DISSECTION;
 
   _ws_tvb = tvb;
-  mrb_value mrb_config = mrb_ws_protocol_start("");
+
+  FILE *config_src     = fopen(config_src_path, "r");
+  mrb_value mrb_config = mrb_load_file(_mrb, config_src);
   mrb_value mrb_name   = mrb_iv_get(_mrb, mrb_config, mrb_intern_lit(_mrb, "@name"));
 
   col_set_str(pinfo->cinfo, COL_PROTOCOL, mrb_string_cstr(_mrb, mrb_name));
@@ -398,43 +400,46 @@ static mrb_value mrb_ws_protocol_config(mrb_state *mrb, mrb_value self)
 
 mrb_value mrb_ws_protocol_start(const char *pathname)
 {
-  if (operation_mode == REGISTERATION) {
-    strcpy(config_src_path, pathname);
-    _mrb = mrb_open();
-
-    FILE *ws_dissector_src = fopen("../plugins/epan/mruby/ws_dissector.rb", "r");
-    FILE *ws_protocol_src  = fopen("../plugins/epan/mruby/ws_protocol.rb", "r");
-    mrb_load_file(_mrb, ws_dissector_src);
-    mrb_load_file(_mrb, ws_protocol_src);
-
-    mrb_value      mrb_pklass = mrb_obj_value(mrb_class_get(_mrb, "WSProtocol"));
-    struct RClass *pklass     = mrb_class_ptr(mrb_pklass);
-
-    mrb_define_method(_mrb, pklass, "initialize", mrb_ws_protocol_init,      MRB_ARGS_REQ(1));
-    mrb_define_method(_mrb, pklass, "register!",  mrb_ws_protocol_register,  MRB_ARGS_NONE());
-    mrb_define_method(_mrb, pklass, "dissect!",   mrb_ws_protocol_dissector, MRB_ARGS_NONE());
-    mrb_define_method(_mrb, pklass, "value_at",   mrb_ws_protocol_value,     MRB_ARGS_ARG(1, 2));
-
-    mrb_define_class_method(_mrb, pklass,
-                            "configure", mrb_ws_protocol_config, MRB_ARGS_REQ(1) | MRB_ARGS_BLOCK());
-
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_INT8"),   mrb_fixnum_value(FT_INT8));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_UINT8"),  mrb_fixnum_value(FT_UINT8));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_INT16"),  mrb_fixnum_value(FT_INT16));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_UINT16"), mrb_fixnum_value(FT_UINT16));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_INT32"),  mrb_fixnum_value(FT_INT32));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_UINT32"), mrb_fixnum_value(FT_UINT32));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_IPv4"),   mrb_fixnum_value(FT_IPv4));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_STRING"), mrb_fixnum_value(FT_STRING));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "BASE_DEC"),  mrb_fixnum_value(BASE_DEC));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "BASE_HEX"),  mrb_fixnum_value(BASE_HEX));
-    mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "BASE_NONE"), mrb_fixnum_value(BASE_NONE));
-
-    mrb_value mrb_dklass = mrb_obj_value(mrb_class_get(_mrb, "WSDissector"));
-    mrb_const_set(_mrb, mrb_dklass, mrb_intern_lit(_mrb, "ENC_NA"),            mrb_fixnum_value(ENC_NA));
-    mrb_const_set(_mrb, mrb_dklass, mrb_intern_lit(_mrb, "ENC_BIG_ENDIAN"),    mrb_fixnum_value(ENC_BIG_ENDIAN));
-    mrb_const_set(_mrb, mrb_dklass, mrb_intern_lit(_mrb, "ENC_LITTLE_ENDIAN"), mrb_fixnum_value(ENC_LITTLE_ENDIAN));
+  if (operation_mode != REGISTERATION) {
+    perror("mrb_ws_protocol_start() can only be executed when operation_mode is REGISTRATION!");
+    exit(1);
   }
+
+  strcpy(config_src_path, pathname);
+  _mrb = mrb_open();
+
+  FILE *ws_dissector_src = fopen("../plugins/epan/mruby/ws_dissector.rb", "r");
+  FILE *ws_protocol_src  = fopen("../plugins/epan/mruby/ws_protocol.rb", "r");
+  mrb_load_file(_mrb, ws_dissector_src);
+  mrb_load_file(_mrb, ws_protocol_src);
+
+  mrb_value      mrb_pklass = mrb_obj_value(mrb_class_get(_mrb, "WSProtocol"));
+  struct RClass *pklass     = mrb_class_ptr(mrb_pklass);
+
+  mrb_define_method(_mrb, pklass, "initialize", mrb_ws_protocol_init,      MRB_ARGS_REQ(1));
+  mrb_define_method(_mrb, pklass, "register!",  mrb_ws_protocol_register,  MRB_ARGS_NONE());
+  mrb_define_method(_mrb, pklass, "dissect!",   mrb_ws_protocol_dissector, MRB_ARGS_NONE());
+  mrb_define_method(_mrb, pklass, "value_at",   mrb_ws_protocol_value,     MRB_ARGS_ARG(1, 2));
+
+  mrb_define_class_method(_mrb, pklass,
+                          "configure", mrb_ws_protocol_config, MRB_ARGS_REQ(1) | MRB_ARGS_BLOCK());
+
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_INT8"),   mrb_fixnum_value(FT_INT8));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_UINT8"),  mrb_fixnum_value(FT_UINT8));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_INT16"),  mrb_fixnum_value(FT_INT16));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_UINT16"), mrb_fixnum_value(FT_UINT16));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_INT32"),  mrb_fixnum_value(FT_INT32));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_UINT32"), mrb_fixnum_value(FT_UINT32));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_IPv4"),   mrb_fixnum_value(FT_IPv4));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "FT_STRING"), mrb_fixnum_value(FT_STRING));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "BASE_DEC"),  mrb_fixnum_value(BASE_DEC));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "BASE_HEX"),  mrb_fixnum_value(BASE_HEX));
+  mrb_const_set(_mrb, mrb_pklass, mrb_intern_lit(_mrb, "BASE_NONE"), mrb_fixnum_value(BASE_NONE));
+
+  mrb_value mrb_dklass = mrb_obj_value(mrb_class_get(_mrb, "WSDissector"));
+  mrb_const_set(_mrb, mrb_dklass, mrb_intern_lit(_mrb, "ENC_NA"),            mrb_fixnum_value(ENC_NA));
+  mrb_const_set(_mrb, mrb_dklass, mrb_intern_lit(_mrb, "ENC_BIG_ENDIAN"),    mrb_fixnum_value(ENC_BIG_ENDIAN));
+  mrb_const_set(_mrb, mrb_dklass, mrb_intern_lit(_mrb, "ENC_LITTLE_ENDIAN"), mrb_fixnum_value(ENC_LITTLE_ENDIAN));
 
   FILE *config_src = fopen(config_src_path, "r");
   return mrb_load_file(_mrb, config_src);

--- a/plugins/epan/mruby/ws_protocol.c
+++ b/plugins/epan/mruby/ws_protocol.c
@@ -3,13 +3,13 @@
 #define MRB_SYM(mrb, name) mrb_symbol_value(mrb_intern_lit(mrb, name))
 
 typedef enum {
-  REGISTERATION,
+  REGISTRATION,
   DISSECTION,
 } OperationMode;
 
 char config_src_path[256];
 static int phandle = -1;
-static int operation_mode = REGISTERATION;
+static int operation_mode = REGISTRATION;
 
 typedef struct {
   char name[100];
@@ -355,7 +355,7 @@ static mrb_value mrb_ws_protocol_dissector(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_ws_protocol_value(mrb_state *mrb, mrb_value _self)
 {
-  if (operation_mode == REGISTERATION) return mrb_nil_value();
+  if (operation_mode == REGISTRATION) return mrb_nil_value();
 
   // WIP: Need to add support other packet types --
   mrb_sym type_gint8  = (int)mrb_obj_to_sym(mrb, mrb_str_new_lit(mrb, "gint8"));
@@ -392,7 +392,7 @@ static mrb_value mrb_ws_protocol_config(mrb_state *mrb, mrb_value self)
 
   mrb_value mrb_config = mrb_nil_value();
 
-  if (operation_mode == REGISTERATION) mrb_config = mrb_funcall(mrb, proto, "register!", 0);
+  if (operation_mode == REGISTRATION) mrb_config = mrb_funcall(mrb, proto, "register!", 0);
   if (operation_mode == DISSECTION)    mrb_config = mrb_funcall(mrb, proto, "dissect!", 0);
 
   return mrb_config;
@@ -400,7 +400,7 @@ static mrb_value mrb_ws_protocol_config(mrb_state *mrb, mrb_value self)
 
 mrb_value mrb_ws_protocol_start(const char *pathname)
 {
-  if (operation_mode != REGISTERATION) {
+  if (operation_mode != REGISTRATION) {
     perror("mrb_ws_protocol_start() can only be executed when operation_mode is REGISTRATION!");
     exit(1);
   }


### PR DESCRIPTION
Since https://github.com/shioimm/wireshark_with_mruby/pull/13 allows `mrb_ws_prptocol_start` to  execute initialization only when Wireshark starts, `mrb_ws_prptocol_start` is unneeded to execute when traffic is occurred anymore.